### PR TITLE
WIP: add function: chdb() to return version

### DIFF
--- a/src/Functions/chdbVersion.cpp
+++ b/src/Functions/chdbVersion.cpp
@@ -1,0 +1,33 @@
+#include <DataTypes/DataTypeString.h>
+#include <Functions/FunctionFactory.h>
+
+namespace DB
+{
+
+namespace
+{
+    /// chdb() - returns the current chdb version as a string.
+    class FunctionChdbVersion : public FunctionConstantBase<FunctionChdbVersion, String, DataTypeString>
+    {
+    public:
+        static constexpr auto name = "chdb";
+        static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionChdbVersion>(context); }
+        explicit FunctionChdbVersion(ContextPtr context) : FunctionConstantBase(CHDB_VERSION_STRING, context->isDistributed()) {}
+    };
+}
+  
+#if defined(CHDB_VERSION_STRING)
+REGISTER_FUNCTION(ChdbVersion)
+{
+    factory.registerFunction<FunctionChdbVersion>(
+        {
+        R"(
+Returns the version of chDB.  The result type is String.
+        )",
+        Documentation::Examples{{"chdb", "SELECT chdb()"}},
+        Documentation::Categories{"String"}
+        }, FunctionFactory::CaseInsensitive);
+}
+#endif
+
+}


### PR DESCRIPTION
**WORK IN PROGRESS FOR REVIEW - UNTESTED**

This PR adds a simple C++ function `chdb()` with no parameters that returns the current version of chDB as a string. 
The version number is defined using the `CHDB_VERSION_STRING` macro, which should be defined during the build process.

The `FunctionChdbVersion` class is a subclass of `FunctionConstantBase`, which is a base class for functions that return a constant value. The `FunctionChdbVersion` constructor takes the `CHDB_VERSION_STRING` macro as an argument, which is passed to the `FunctionConstantBase` constructor to set the constant value of the function.

The `REGISTER_FUNCTION` macro is conditionally compiled using an `#if` directive that checks whether the `CHDB_VERSION_STRING` macro is defined, to avoid registering the function if the version number is not available.

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
add function `chdb()` returning the current build version
